### PR TITLE
fix: #27 チェックボックスチェックの際にプロパティーが抜けるのを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,13 +205,12 @@
 
         const handleTodoCheckboxChange = (id) => {
           const newTodos = todos.map((todo) => {
-            return {
-              id: todo.id,
-              title: todo.title,
-              isCompleted: todo.id === id? !todo.isCompleted : todo.isCompleted,
-            };
+            if (todo.id === id) {
+              return { ...todo, isCompleted: !todo.isCompleted };
+            }
+            return todo;
           });
-            updateTodos(newTodos);
+          updateTodos(newTodos);
 
         };
         const handleTodoDeleteClick = (id) => {


### PR DESCRIPTION
*  todosが更新される、つまり、stateの更新が起こり再レンダリングされるが、更新の過程でプロパティーが欠落していた。
* 欠落分を素直に書き足せばいいが、欠落を防ぐ手段としては下記。
* return で全部のプロパティーを列挙するのではなく、if文＋スプレッド構文でisCompletedプロパティーのみの書き換え、チェックされていない時はそのまま返せばいい。